### PR TITLE
feat: add request details page

### DIFF
--- a/app/designer/requests/[id]/page.tsx
+++ b/app/designer/requests/[id]/page.tsx
@@ -1,1 +1,24 @@
-{"code":"rate-limited","message":"You have hit the rate limit. Please <a class=\"__boltUpgradePlan__\">Upgrade</a> to keep chatting, or you can continue coding for free in the editor.","providerLimitHit":false,"isRetryable":true}
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+interface RequestPageProps {
+  params: { id: string }
+}
+
+export default function DesignerRequestPage({ params }: RequestPageProps) {
+  return (
+    <div className="container py-8 space-y-4">
+      <h1 className="text-2xl font-bold">Request {params.id}</h1>
+      <p className="text-muted-foreground">
+        Placeholder details for request {params.id}.
+      </p>
+      <div className="flex gap-2">
+        <Link href="/designer/requests">
+          <Button variant="outline">Back</Button>
+        </Link>
+        <Button>Take Request</Button>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add designer request detail page reading dynamic route id

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unescaped-entities in existing pages)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d39d522c83218a462eb457327da4