### PR TITLE
feat: add request heat tracking

### DIFF
--- a/app/api/heat/[clientId]/route.ts
+++ b/app/api/heat/[clientId]/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getHeat, recordRequest } from "@/lib/heat";
+
+export async function GET(_req: NextRequest, { params }: { params: { clientId: string } }) {
+  const data = getHeat(params.clientId);
+  return NextResponse.json(data);
+}
+
+export async function POST(_req: NextRequest, { params }: { params: { clientId: string } }) {
+  const result = recordRequest(params.clientId);
+  const status = result.blocked ? 429 : 200;
+  return NextResponse.json(result.data, { status });
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -112,7 +112,7 @@ export default function LoginPage() {
           </Form>
           <div className="text-center">
             <p className="text-sm text-muted-foreground">
-              Don't have an account?{" "}
+              Don&apos;t have an account?{" "}
               <Link href="/auth/signup" className="underline underline-offset-2 hover:text-foreground">
                 Sign up
               </Link>

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
@@ -11,7 +12,7 @@ import {
 } from "lucide-react"
 import { RequestList } from "@/components/request-list"
 import { ThermometerDisplay } from "@/components/thermometer-display"
-import { DesignRequest } from "@/types"
+import { DesignRequest, ThermometerData } from "@/types"
 
 // Mock data
 const activeRequests: DesignRequest[] = [
@@ -58,15 +59,15 @@ const completedRequests: DesignRequest[] = [
   }
 ];
 
-// Mock thermometer data
-const thermometerData = {
-  currentLevel: 65, // 0-100
-  maxRequests: 5,
-  currentRequests: 3,
-  cooldownDate: undefined // No cooldown
-};
-
 export default function ClientDashboard() {
+  const [thermometerData, setThermometerData] = useState<ThermometerData | null>(null)
+
+  useEffect(() => {
+    fetch("/api/heat/client1")
+      .then((res) => res.json())
+      .then(setThermometerData)
+  }, [])
+
   return (
     <div className="container py-8 md:py-12 space-y-10">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
@@ -131,18 +132,28 @@ export default function ClientDashboard() {
             <CardDescription className="text-base">Your current request volume</CardDescription>
           </CardHeader>
           <CardContent>
-            <ThermometerDisplay data={thermometerData} />
+            <ThermometerDisplay
+              data={
+                thermometerData ?? {
+                  currentLevel: 0,
+                  maxRequests: 5,
+                  currentRequests: 0,
+                }
+              }
+            />
             <div className="mt-6 text-sm">
               <p className="flex justify-between">
                 <span>Requests this week:</span>
-                <span className="font-medium">{thermometerData.currentRequests} of {thermometerData.maxRequests}</span>
+                <span className="font-medium">
+                  {thermometerData?.currentRequests ?? 0} of {thermometerData?.maxRequests ?? 5}
+                </span>
               </p>
-              
-              {thermometerData.currentLevel >= 80 ? (
+
+              {thermometerData?.currentLevel >= 80 ? (
                 <div className="mt-4 p-3 bg-amber-100 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-xl flex items-start gap-2">
                   <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                   <p className="text-amber-800 dark:text-amber-300 text-xs">
-                    You're nearing your request limit. Consider spacing out new requests.
+                    You&apos;re nearing your request limit. Consider spacing out new requests.
                   </p>
                 </div>
               ) : null}

--- a/app/client/new-request/page.tsx
+++ b/app/client/new-request/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
@@ -53,7 +53,7 @@ import {
 import { cn } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast"
 import { ThermometerDisplay } from "@/components/thermometer-display"
-import { RequestCategory } from "@/types"
+import { RequestCategory, ThermometerData } from "@/types"
 
 const requestCategories: RequestCategory[] = [
   "Logo Design",
@@ -75,19 +75,18 @@ const formSchema = z.object({
   priority: z.enum(["low", "medium", "high", "urgent"])
 });
 
-// Mock thermometer data - high temperature
-const thermometerData = {
-  currentLevel: 85, // 0-100
-  maxRequests: 5,
-  currentRequests: 4,
-  cooldownDate: undefined
-};
-
 export default function NewRequestPage() {
   const router = useRouter()
   const { toast } = useToast()
   const [isLoading, setIsLoading] = useState(false)
   const [showWarning, setShowWarning] = useState(false)
+  const [thermometerData, setThermometerData] = useState<ThermometerData | null>(null)
+
+  useEffect(() => {
+    fetch("/api/heat/client1")
+      .then((res) => res.json())
+      .then(setThermometerData)
+  }, [])
   
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -100,28 +99,32 @@ export default function NewRequestPage() {
   })
   
   function onSubmit(values: z.infer<typeof formSchema>) {
-    // If thermometer is hot, show warning
-    if (thermometerData.currentLevel > 80) {
-      setShowWarning(true)
-      return
-    }
-    
     submitRequest(values)
   }
-  
+
   function submitRequest(values: z.infer<typeof formSchema>) {
     setIsLoading(true)
-    
-    // Mock submission process
-    setTimeout(() => {
-      toast({
-        title: "Request submitted",
-        description: "Your design request has been submitted successfully.",
+
+    fetch("/api/heat/client1", { method: "POST" })
+      .then(async (res) => {
+        const data = await res.json()
+        setThermometerData(data)
+        if (res.status === 429) {
+          setShowWarning(true)
+          setIsLoading(false)
+          return
+        }
+
+        setTimeout(() => {
+          toast({
+            title: "Request submitted",
+            description: "Your design request has been submitted successfully.",
+          })
+
+          router.push("/client/dashboard")
+          setIsLoading(false)
+        }, 1500)
       })
-      
-      router.push("/client/dashboard")
-      setIsLoading(false)
-    }, 1500)
   }
 
   return (
@@ -295,14 +298,22 @@ export default function NewRequestPage() {
             <CardContent className="pt-6">
               <div className="space-y-4">
                 <h3 className="text-lg font-medium">Request Thermometer</h3>
-                <ThermometerDisplay data={thermometerData} />
+                <ThermometerDisplay
+                  data={
+                    thermometerData ?? {
+                      currentLevel: 0,
+                      maxRequests: 5,
+                      currentRequests: 0,
+                    }
+                  }
+                />
                 
                 <div className="rounded-md bg-amber-50 dark:bg-amber-950 p-3 text-sm text-amber-900 dark:text-amber-200 flex items-start gap-2 border border-amber-200 dark:border-amber-900">
                   <Info className="h-5 w-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
                   <div>
                     <p className="font-medium mb-1">Your request volume is high</p>
                     <p className="text-xs">
-                      You've submitted several requests recently. You may experience slightly longer turnaround times.
+                      You&apos;ve submitted several requests recently. You may experience slightly longer turnaround times.
                     </p>
                   </div>
                 </div>
@@ -343,14 +354,12 @@ export default function NewRequestPage() {
               Request Volume Warning
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Your request volume is currently high. Adding more requests may result in longer turnaround times.
-              Do you still want to proceed with submitting this request?
+              Your request volume is currently high. Please wait for the cooldown before submitting new requests.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => submitRequest(form.getValues())}>
-              Submit Anyway
+            <AlertDialogAction onClick={() => setShowWarning(false)}>
+              Okay
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/designer/requests/[id]/page.tsx
+++ b/app/designer/requests/[id]/page.tsx
@@ -1,1 +1,3 @@
-{"code":"rate-limited","message":"You have hit the rate limit. Please <a class=\"__boltUpgradePlan__\">Upgrade</a> to keep chatting, or you can continue coding for free in the editor.","providerLimitHit":false,"isRetryable":true}
+export default function DesignerRequestPage() {
+  return <div>Designer Request</div>
+}

--- a/lib/heat.ts
+++ b/lib/heat.ts
@@ -1,0 +1,52 @@
+import { ThermometerData } from "@/types";
+
+interface HeatRecord {
+  count: number;
+  cooldownUntil?: number;
+}
+
+const MAX_REQUESTS = 5;
+const COOLDOWN_MS = 1000 * 60 * 60; // 1 hour
+
+const store: Record<string, HeatRecord> = {};
+
+function cleanup(record: HeatRecord) {
+  if (record.cooldownUntil && Date.now() > record.cooldownUntil) {
+    record.count = 0;
+    record.cooldownUntil = undefined;
+  }
+}
+
+function toData(record: HeatRecord): ThermometerData {
+  const level = Math.min(100, (record.count / MAX_REQUESTS) * 100);
+  return {
+    currentLevel: level,
+    maxRequests: MAX_REQUESTS,
+    currentRequests: record.count,
+    cooldownDate: record.cooldownUntil ? new Date(record.cooldownUntil).toISOString() : undefined,
+  };
+}
+
+export function getHeat(clientId: string): ThermometerData {
+  const record = store[clientId] || { count: 0 };
+  cleanup(record);
+  store[clientId] = record;
+  return toData(record);
+}
+
+export function recordRequest(clientId: string): { blocked: boolean; data: ThermometerData } {
+  const record = store[clientId] || { count: 0 };
+  cleanup(record);
+
+  if (record.cooldownUntil && Date.now() < record.cooldownUntil) {
+    return { blocked: true, data: toData(record) };
+  }
+
+  record.count += 1;
+  if (record.count >= MAX_REQUESTS) {
+    record.cooldownUntil = Date.now() + COOLDOWN_MS;
+  }
+
+  store[clientId] = record;
+  return { blocked: false, data: toData(record) };
+}


### PR DESCRIPTION
## Summary
- track per-client request heat and cooldown data
- expose heat endpoints and block submissions when hot
- show live heat scores on dashboards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4d39fbc78832197cfbedad87591e7