### PR TITLE
test: add api unit tests and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -112,7 +112,7 @@ export default function LoginPage() {
           </Form>
           <div className="text-center">
             <p className="text-sm text-muted-foreground">
-              Don't have an account?{" "}
+              Don&apos;t have an account?{" "}
               <Link href="/auth/signup" className="underline underline-offset-2 hover:text-foreground">
                 Sign up
               </Link>

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -142,7 +142,7 @@ export default function ClientDashboard() {
                 <div className="mt-4 p-3 bg-amber-100 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-xl flex items-start gap-2">
                   <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                   <p className="text-amber-800 dark:text-amber-300 text-xs">
-                    You're nearing your request limit. Consider spacing out new requests.
+                    You&apos;re nearing your request limit. Consider spacing out new requests.
                   </p>
                 </div>
               ) : null}

--- a/app/client/new-request/page.tsx
+++ b/app/client/new-request/page.tsx
@@ -302,7 +302,7 @@ export default function NewRequestPage() {
                   <div>
                     <p className="font-medium mb-1">Your request volume is high</p>
                     <p className="text-xs">
-                      You've submitted several requests recently. You may experience slightly longer turnaround times.
+                      You&apos;ve submitted several requests recently. You may experience slightly longer turnaround times.
                     </p>
                   </div>
                 </div>

--- a/app/designer/requests/[id]/page.tsx
+++ b/app/designer/requests/[id]/page.tsx
@@ -1,1 +1,3 @@
-{"code":"rate-limited","message":"You have hit the rate limit. Please <a class=\"__boltUpgradePlan__\">Upgrade</a> to keep chatting, or you can continue coding for free in the editor.","providerLimitHit":false,"isRetryable":true}
+export default function DesignerRequestPage() {
+  return <div>Request Details</div>;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,23 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  testEnvironment: 'jsdom',
+  coverageThreshold: {
+    global: {
+      statements: 80,
+      branches: 80,
+      lines: 80,
+      functions: 80,
+    },
+  },
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/lib/api/__tests__/auth.test.ts
+++ b/lib/api/__tests__/auth.test.ts
@@ -1,0 +1,28 @@
+import { login } from '@/lib/api/auth';
+
+describe('auth API', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  it('posts credentials and returns data when successful', async () => {
+    const mockResponse = { token: 'abc123' };
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => mockResponse });
+
+    const result = await login({ email: 'user@example.com', password: 'secret' });
+
+    expect(fetch).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com', password: 'secret' }),
+    }));
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('throws an error when response is not ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    await expect(login({ email: 'user@example.com', password: 'secret' })).rejects.toThrow('Login failed');
+  });
+});

--- a/lib/api/__tests__/request.test.ts
+++ b/lib/api/__tests__/request.test.ts
@@ -1,0 +1,66 @@
+import { fetchRequests, createRequest } from '@/lib/api/request';
+import { DesignRequest } from '@/types';
+
+describe('request API', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  it('fetchRequests returns data on success', async () => {
+    const mockData: DesignRequest[] = [
+      {
+        id: '1',
+        clientId: 'client1',
+        title: 'Logo',
+        description: 'Create a logo',
+        category: 'Logo Design',
+        status: 'pending',
+        priority: 'medium',
+        deadline: '2024-01-01',
+        createdAt: '2023-01-01',
+        updatedAt: '2023-01-01',
+      },
+    ];
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => mockData });
+
+    const result = await fetchRequests();
+    expect(fetch).toHaveBeenCalledWith('/api/requests');
+    expect(result).toEqual(mockData);
+  });
+
+  it('fetchRequests throws when response not ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false });
+    await expect(fetchRequests()).rejects.toThrow('Failed to fetch requests');
+  });
+
+  it('createRequest posts data and returns result', async () => {
+    const newRequest = { title: 'Site', description: 'Build site' } as Partial<DesignRequest>;
+    const created: DesignRequest = {
+      id: '2',
+      clientId: 'client1',
+      title: 'Site',
+      description: 'Build site',
+      category: 'Web Design',
+      status: 'pending',
+      priority: 'medium',
+      deadline: '2024-02-01',
+      createdAt: '2023-02-01',
+      updatedAt: '2023-02-01',
+    };
+    (fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => created });
+
+    const result = await createRequest(newRequest);
+    expect(fetch).toHaveBeenCalledWith('/api/requests', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newRequest),
+    }));
+    expect(result).toEqual(created);
+  });
+
+  it('createRequest throws when response not ok', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false });
+    await expect(createRequest({ title: 'Test' } as Partial<DesignRequest>)).rejects.toThrow('Failed to create request');
+  });
+});

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,22 @@
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+}
+
+export async function login({ email, password }: LoginCredentials): Promise<LoginResponse> {
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Login failed');
+  }
+
+  return res.json();
+}

--- a/lib/api/request.ts
+++ b/lib/api/request.ts
@@ -1,0 +1,21 @@
+import { DesignRequest } from '@/types';
+
+export async function fetchRequests(): Promise<DesignRequest[]> {
+  const res = await fetch('/api/requests');
+  if (!res.ok) {
+    throw new Error('Failed to fetch requests');
+  }
+  return res.json();
+}
+
+export async function createRequest(data: Partial<DesignRequest>): Promise<DesignRequest> {
+  const res = await fetch('/api/requests', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create request');
+  }
+  return res.json();
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -67,5 +68,13 @@
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.5",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest with coverage thresholds
- add unit tests for auth and request APIs
- run tests and lint in CI

## Testing
- `npm test` (fails: jest not found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3a0d02883219a6b022780e18a59